### PR TITLE
Extract lessons list utilities

### DIFF
--- a/src/features/LessonsListScreen/constants.ts
+++ b/src/features/LessonsListScreen/constants.ts
@@ -1,0 +1,125 @@
+import type { LessonDifficulty, LessonType, TaskType, TaskTypeInfo } from '../../types';
+
+// Enhanced tag system types
+export type TagCategory = 'context' | 'skill' | 'function' | 'media' | 'level' | 'general';
+
+export interface EnhancedTag {
+  id: string;
+  label: string;
+  icon: string;
+  category: TagCategory;
+  color: string;
+  bgColor: string;
+  priority: number; // Higher number = higher priority for display
+}
+
+// Task types configuration
+export const TASK_TYPES_CONFIG: Record<TaskType, TaskTypeInfo> = {
+  flashcard: {
+    type: 'flashcard',
+    label: 'Карточки',
+    icon: '📚',
+    color: 'rgba(139, 69, 19, 0.8)',
+    description: 'Изучение слов и фраз'
+  },
+  multiple_choice: {
+    type: 'multiple_choice',
+    label: 'Тест',
+    icon: '✓',
+    color: 'rgba(59, 130, 246, 0.8)',
+    description: 'Выбор правильного ответа'
+  },
+  matching: {
+    type: 'matching',
+    label: 'Соединить',
+    icon: '⚡',
+    color: 'rgba(168, 85, 247, 0.8)',
+    description: 'Соединение слов с переводом'
+  },
+  gap_fill: {
+    type: 'gap_fill',
+    label: 'Вставить',
+    icon: '✎',
+    color: 'rgba(34, 197, 94, 0.8)',
+    description: 'Заполнение пропусков'
+  },
+  listening: {
+    type: 'listening',
+    label: 'Слушать',
+    icon: '🔊',
+    color: 'rgba(245, 101, 101, 0.8)',
+    description: 'Аудирование'
+  }
+};
+
+// Professional tag configuration
+export const TAG_CONFIG: Record<string, EnhancedTag> = {
+  // Context tags (places/situations)
+  'airport': { id: 'airport', label: 'Аэропорт', icon: '✈️', category: 'context', color: 'text-blue-700', bgColor: 'bg-blue-100', priority: 8 },
+  'hotel': { id: 'hotel', label: 'Отель', icon: '🏨', category: 'context', color: 'text-purple-700', bgColor: 'bg-purple-100', priority: 7 },
+  'restaurant': { id: 'restaurant', label: 'Ресторан', icon: '🍽️', category: 'context', color: 'text-orange-700', bgColor: 'bg-orange-100', priority: 7 },
+  'city': { id: 'city', label: 'Город', icon: '🏙️', category: 'context', color: 'text-gray-700', bgColor: 'bg-gray-100', priority: 6 },
+  'transport': { id: 'transport', label: 'Транспорт', icon: '🚌', category: 'context', color: 'text-green-700', bgColor: 'bg-green-100', priority: 6 },
+
+  // Skill tags (what is being learned)
+  'greetings': { id: 'greetings', label: 'Приветствие', icon: '👋', category: 'skill', color: 'text-yellow-700', bgColor: 'bg-yellow-100', priority: 9 },
+  'basics': { id: 'basics', label: 'Основы', icon: '📚', category: 'skill', color: 'text-indigo-700', bgColor: 'bg-indigo-100', priority: 8 },
+  'pronunciation': { id: 'pronunciation', label: 'Произношение', icon: '🗣️', category: 'skill', color: 'text-pink-700', bgColor: 'bg-pink-100', priority: 7 },
+  'vocabulary': { id: 'vocabulary', label: 'Словарь', icon: '📖', category: 'skill', color: 'text-teal-700', bgColor: 'bg-teal-100', priority: 6 },
+
+  // Function tags (purpose/goal)
+  'ordering': { id: 'ordering', label: 'Заказ', icon: '📝', category: 'function', color: 'text-red-700', bgColor: 'bg-red-100', priority: 7 },
+  'directions': { id: 'directions', label: 'Направления', icon: '🧭', category: 'function', color: 'text-blue-700', bgColor: 'bg-blue-100', priority: 7 },
+  'check-in': { id: 'check-in', label: 'Регистрация', icon: '🏨', category: 'function', color: 'text-purple-700', bgColor: 'bg-purple-100', priority: 6 },
+  'security': { id: 'security', label: 'Безопасность', icon: '🔒', category: 'function', color: 'text-gray-700', bgColor: 'bg-gray-100', priority: 8 },
+  'customs': { id: 'customs', label: 'Таможня', icon: '🛂', category: 'function', color: 'text-indigo-700', bgColor: 'bg-indigo-100', priority: 6 },
+  'passport': { id: 'passport', label: 'Паспорт', icon: '📘', category: 'function', color: 'text-blue-700', bgColor: 'bg-blue-100', priority: 7 },
+
+  // Media tags (content format)
+  'audio': { id: 'audio', label: 'Аудио', icon: '🎵', category: 'media', color: 'text-green-600', bgColor: 'bg-green-50', priority: 5 },
+  'video': { id: 'video', label: 'Видео', icon: '🎬', category: 'media', color: 'text-red-600', bgColor: 'bg-red-50', priority: 5 },
+  'interactive': { id: 'interactive', label: 'Интерактив', icon: '🎮', category: 'media', color: 'text-purple-600', bgColor: 'bg-purple-50', priority: 4 },
+
+  // Level tags (special markers)
+  'beginner': { id: 'beginner', label: 'Новичок', icon: '🌱', category: 'level', color: 'text-green-600', bgColor: 'bg-green-50', priority: 6 },
+  'popular': { id: 'popular', label: 'Популярный', icon: '🔥', category: 'level', color: 'text-orange-600', bgColor: 'bg-orange-50', priority: 9 },
+  'important': { id: 'important', label: 'Важный', icon: '⭐', category: 'level', color: 'text-yellow-600', bgColor: 'bg-yellow-50', priority: 10 },
+  'new': { id: 'new', label: 'Новый', icon: '✨', category: 'level', color: 'text-blue-600', bgColor: 'bg-blue-50', priority: 8 },
+
+  // General tags (fallback)
+  'general': { id: 'general', label: 'Общее', icon: '🏷️', category: 'general', color: 'text-gray-600', bgColor: 'bg-gray-50', priority: 1 }
+};
+
+export const LESSON_TYPE_LABELS: Record<LessonType, string> = {
+  conversation: 'Разговор',
+  vocabulary: 'Словарь',
+  listening: 'Аудирование',
+  grammar: 'Грамматика',
+  speaking: 'Говорение',
+  reading: 'Чтение',
+  writing: 'Письмо'
+};
+
+export const LESSON_TYPE_ICONS: Record<LessonType, string> = {
+  conversation: '💬',
+  vocabulary: '📚',
+  listening: '🎧',
+  grammar: '📝',
+  speaking: '🎤',
+  reading: '📖',
+  writing: '✍️'
+};
+
+export const LESSON_DIFFICULTY_COLORS: Record<LessonDifficulty, string> = {
+  easy: 'text-green-600 bg-green-50',
+  medium: 'text-yellow-600 bg-yellow-50',
+  hard: 'text-red-600 bg-red-50'
+};
+
+export const LESSON_DIFFICULTY_LABELS: Record<LessonDifficulty, string> = {
+  easy: 'Легко',
+  medium: 'Средне',
+  hard: 'Сложно'
+};
+
+export const LESSONS_PER_PAGE = 5;

--- a/src/features/LessonsListScreen/index.tsx
+++ b/src/features/LessonsListScreen/index.tsx
@@ -8,289 +8,29 @@ import { APP_STATES } from '../../utils/constants';
 import { tracking } from '../../services/tracking';
 import { hapticFeedback } from '../../utils/telegram';
 import { useAudioPreload } from '../../utils/audio';
-import type { LessonItem, LessonType, LessonDifficulty, TaskType, TaskTypeInfo } from '../../types';
+import type { LessonItem, LessonType, LessonDifficulty, TaskType } from '../../types';
+import {
+  LESSONS_PER_PAGE,
+  LESSON_DIFFICULTY_COLORS,
+  LESSON_DIFFICULTY_LABELS,
+  TASK_TYPES_CONFIG,
+  type EnhancedTag
+} from './constants';
+import {
+  getAvailableLessonTypes,
+  getDefaultTaskTypes,
+  getEnhancedTags,
+  getLessonTypeIcon,
+  getLessonTypeLabel,
+  mapApiTaskTypes
+} from './utils';
 import './styles.lessonsList.css';
-
-// Enhanced tag system types
-type TagCategory = 'context' | 'skill' | 'function' | 'media' | 'level' | 'general';
-
-interface EnhancedTag {
-  id: string;
-  label: string;
-  icon: string;
-  category: TagCategory;
-  color: string;
-  bgColor: string;
-  priority: number; // Higher number = higher priority for display
-}
 
 interface LessonsListScreenProps {
   moduleRef?: string;
   moduleTitle?: string;
   level?: string;
 }
-
-// Task types configuration
-const TASK_TYPES_CONFIG: Record<TaskType, TaskTypeInfo> = {
-  flashcard: {
-    type: 'flashcard',
-    label: 'Карточки',
-    icon: '📚',
-    color: 'rgba(139, 69, 19, 0.8)',
-    description: 'Изучение слов и фраз'
-  },
-  multiple_choice: {
-    type: 'multiple_choice',
-    label: 'Тест',
-    icon: '✓',
-    color: 'rgba(59, 130, 246, 0.8)',
-    description: 'Выбор правильного ответа'
-  },
-  matching: {
-    type: 'matching',
-    label: 'Соединить',
-    icon: '⚡',
-    color: 'rgba(168, 85, 247, 0.8)',
-    description: 'Соединение слов с переводом'
-  },
-  gap_fill: {
-    type: 'gap_fill',
-    label: 'Вставить',
-    icon: '✎',
-    color: 'rgba(34, 197, 94, 0.8)',
-    description: 'Заполнение пропусков'
-  },
-  listening: {
-    type: 'listening',
-    label: 'Слушать',
-    icon: '🔊',
-    color: 'rgba(245, 101, 101, 0.8)',
-    description: 'Аудирование'
-  }
-};
-
-// Professional tag configuration
-const TAG_CONFIG: Record<string, EnhancedTag> = {
-  // Context tags (places/situations)
-  'airport': { id: 'airport', label: 'Аэропорт', icon: '✈️', category: 'context', color: 'text-blue-700', bgColor: 'bg-blue-100', priority: 8 },
-  'hotel': { id: 'hotel', label: 'Отель', icon: '🏨', category: 'context', color: 'text-purple-700', bgColor: 'bg-purple-100', priority: 7 },
-  'restaurant': { id: 'restaurant', label: 'Ресторан', icon: '🍽️', category: 'context', color: 'text-orange-700', bgColor: 'bg-orange-100', priority: 7 },
-  'city': { id: 'city', label: 'Город', icon: '🏙️', category: 'context', color: 'text-gray-700', bgColor: 'bg-gray-100', priority: 6 },
-  'transport': { id: 'transport', label: 'Транспорт', icon: '🚌', category: 'context', color: 'text-green-700', bgColor: 'bg-green-100', priority: 6 },
-  
-  // Skill tags (what is being learned)
-  'greetings': { id: 'greetings', label: 'Приветствие', icon: '👋', category: 'skill', color: 'text-yellow-700', bgColor: 'bg-yellow-100', priority: 9 },
-  'basics': { id: 'basics', label: 'Основы', icon: '📚', category: 'skill', color: 'text-indigo-700', bgColor: 'bg-indigo-100', priority: 8 },
-  'pronunciation': { id: 'pronunciation', label: 'Произношение', icon: '🗣️', category: 'skill', color: 'text-pink-700', bgColor: 'bg-pink-100', priority: 7 },
-  'vocabulary': { id: 'vocabulary', label: 'Словарь', icon: '📖', category: 'skill', color: 'text-teal-700', bgColor: 'bg-teal-100', priority: 6 },
-  
-  // Function tags (purpose/goal)
-  'ordering': { id: 'ordering', label: 'Заказ', icon: '📝', category: 'function', color: 'text-red-700', bgColor: 'bg-red-100', priority: 7 },
-  'directions': { id: 'directions', label: 'Направления', icon: '🧭', category: 'function', color: 'text-blue-700', bgColor: 'bg-blue-100', priority: 7 },
-  'check-in': { id: 'check-in', label: 'Регистрация', icon: '🏨', category: 'function', color: 'text-purple-700', bgColor: 'bg-purple-100', priority: 6 },
-  'security': { id: 'security', label: 'Безопасность', icon: '🔒', category: 'function', color: 'text-gray-700', bgColor: 'bg-gray-100', priority: 8 },
-  'customs': { id: 'customs', label: 'Таможня', icon: '🛂', category: 'function', color: 'text-indigo-700', bgColor: 'bg-indigo-100', priority: 6 },
-  'passport': { id: 'passport', label: 'Паспорт', icon: '📘', category: 'function', color: 'text-blue-700', bgColor: 'bg-blue-100', priority: 7 },
-  
-  // Media tags (content format)
-  'audio': { id: 'audio', label: 'Аудио', icon: '🎵', category: 'media', color: 'text-green-600', bgColor: 'bg-green-50', priority: 5 },
-  'video': { id: 'video', label: 'Видео', icon: '🎬', category: 'media', color: 'text-red-600', bgColor: 'bg-red-50', priority: 5 },
-  'interactive': { id: 'interactive', label: 'Интерактив', icon: '🎮', category: 'media', color: 'text-purple-600', bgColor: 'bg-purple-50', priority: 4 },
-  
-  // Level tags (special markers)
-  'beginner': { id: 'beginner', label: 'Новичок', icon: '🌱', category: 'level', color: 'text-green-600', bgColor: 'bg-green-50', priority: 6 },
-  'popular': { id: 'popular', label: 'Популярный', icon: '🔥', category: 'level', color: 'text-orange-600', bgColor: 'bg-orange-50', priority: 9 },
-  'important': { id: 'important', label: 'Важный', icon: '⭐', category: 'level', color: 'text-yellow-600', bgColor: 'bg-yellow-50', priority: 10 },
-  'new': { id: 'new', label: 'Новый', icon: '✨', category: 'level', color: 'text-blue-600', bgColor: 'bg-blue-50', priority: 8 },
-  
-  // General tags (fallback)
-  'general': { id: 'general', label: 'Общее', icon: '🏷️', category: 'general', color: 'text-gray-600', bgColor: 'bg-gray-50', priority: 1 }
-};
-
-// Utility functions
-const getDefaultTaskTypes = (lessonType: LessonType): TaskType[] => {
-  const taskTypesMap: Record<LessonType, TaskType[]> = {
-    vocabulary: ['flashcard', 'multiple_choice', 'matching'],
-    grammar: ['gap_fill', 'multiple_choice', 'flashcard'],
-    listening: ['listening', 'multiple_choice', 'gap_fill'],
-    speaking: ['flashcard', 'gap_fill', 'multiple_choice'],
-    reading: ['multiple_choice', 'gap_fill', 'flashcard'],
-    writing: ['gap_fill', 'multiple_choice', 'flashcard'],
-    conversation: ['flashcard', 'listening', 'multiple_choice']
-  };
-  
-  return taskTypesMap[lessonType] || ['flashcard', 'multiple_choice'];
-};
-
-// Map API task types to internal TaskType format
-const mapApiTaskTypes = (apiTaskTypes: string[]): TaskType[] => {
-  const taskTypeMapping: Record<string, TaskType> = {
-    'choice': 'multiple_choice',
-    'translate': 'flashcard', // Assuming translate tasks are flashcards
-    'gap': 'gap_fill',
-    'listening': 'listening',
-    'matching': 'matching',
-    'flashcard': 'flashcard',
-    'multiple_choice': 'multiple_choice',
-    'gap_fill': 'gap_fill'
-  };
-  
-  const mappedTypes = apiTaskTypes
-    .map(type => taskTypeMapping[type])
-    .filter((type): type is TaskType => type !== undefined);
-  
-  // Debug logging
-  if (import.meta.env.VITE_ENABLE_DEBUG_LOGGING) {
-    console.log('Mapping API task types:', apiTaskTypes, '->', mappedTypes);
-  }
-  
-  return mappedTypes;
-};
-
-// Get available lesson types from current lessons
-const getAvailableLessonTypes = (lessons: LessonItem[]): Array<{key: LessonType | 'all', label: string, icon: string}> => {
-  const availableTypes = new Set<LessonType>();
-  
-  lessons.forEach(lesson => {
-    if (lesson.type) {
-      availableTypes.add(lesson.type);
-    }
-  });
-  
-  const typeLabels: Record<LessonType, string> = {
-    conversation: 'Разговор',
-    vocabulary: 'Словарь', 
-    listening: 'Аудирование',
-    grammar: 'Грамматика',
-    speaking: 'Говорение',
-    reading: 'Чтение',
-    writing: 'Письмо'
-  };
-  
-  const typeIcons: Record<LessonType, string> = {
-    conversation: '💬',
-    vocabulary: '📚',
-    listening: '🎧', 
-    grammar: '📝',
-    speaking: '🎤',
-    reading: '📖',
-    writing: '✍️'
-  };
-  
-  const options: Array<{key: LessonType | 'all', label: string, icon: string}> = [
-    { key: 'all', label: 'Все', icon: '📚' }
-  ];
-  
-  // Add available types in a consistent order
-  const typeOrder: LessonType[] = ['vocabulary', 'grammar', 'listening', 'speaking', 'reading', 'writing', 'conversation'];
-  
-  typeOrder.forEach(type => {
-    if (availableTypes.has(type)) {
-      options.push({
-        key: type,
-        label: typeLabels[type],
-        icon: typeIcons[type]
-      });
-    }
-  });
-  
-  return options;
-};
-
-const getLessonTypeIcon = (type?: LessonType) => {
-  if (!type) return "📚";
-  const icons = {
-    vocabulary: "📚",
-    grammar: "📝", 
-    listening: "🎧",
-    speaking: "🎤",
-    reading: "📖",
-    writing: "✍️",
-    conversation: "💬"
-  };
-  return icons[type] || "📚";
-};
-
-// Enhanced tag processing functions
-const getEnhancedTags = (lesson: LessonItem): EnhancedTag[] => {
-  const tags: EnhancedTag[] = [];
-  
-  // Add lesson type tag with enhanced styling
-  if (lesson.type) {
-    const typeTag: EnhancedTag = {
-      id: `type-${lesson.type}`,
-      label: getLessonTypeLabel(lesson.type),
-      icon: getLessonTypeIcon(lesson.type),
-      category: 'skill',
-      color: 'text-telegram-accent',
-      bgColor: 'bg-telegram-accent/10',
-      priority: 10
-    };
-    tags.push(typeTag);
-  }
-  
-  // Add media tags based on lesson properties
-  if (lesson.hasAudio) {
-    tags.push(TAG_CONFIG.audio);
-  }
-  if (lesson.hasVideo) {
-    tags.push(TAG_CONFIG.video);
-  }
-  
-  // Process original string tags and map them to enhanced tags
-  lesson.tags?.forEach(tagString => {
-    const enhancedTag = TAG_CONFIG[tagString];
-    if (enhancedTag) {
-      tags.push(enhancedTag);
-    } else {
-      // Create fallback tag for unknown tags
-      tags.push({
-        id: `custom-${tagString}`,
-        label: tagString.charAt(0).toUpperCase() + tagString.slice(1),
-        icon: '🏷️',
-        category: 'general',
-        color: 'text-gray-600',
-        bgColor: 'bg-gray-50',
-        priority: 2
-      });
-    }
-  });
-  
-  // Add special tags based on lesson properties
-  if (lesson.difficulty === 'easy' || lesson.tags?.includes('basics')) {
-    tags.push(TAG_CONFIG.beginner);
-  }
-  
-  // Add "new" tag for recently added lessons (mock logic)
-  if (lesson.order <= 3) {
-    tags.push(TAG_CONFIG.new);
-  }
-  
-  // Add "important" tag for high XP lessons
-  if (lesson.xpReward && lesson.xpReward >= 40) {
-    tags.push(TAG_CONFIG.important);
-  }
-  
-  // Remove duplicates and sort by priority
-  const uniqueTags = tags.filter((tag, index, self) => 
-    index === self.findIndex(t => t.id === tag.id)
-  );
-  
-  return uniqueTags.sort((a, b) => b.priority - a.priority);
-};
-
-const getLessonTypeLabel = (type: LessonType): string => {
-  const labels = {
-    vocabulary: 'Словарь',
-    grammar: 'Грамматика',
-    listening: 'Аудирование',
-    speaking: 'Говорение',
-    reading: 'Чтение',
-    writing: 'Письмо',
-    conversation: 'Разговор'
-  };
-  return labels[type] || 'Урок';
-};
 
 // Enhanced tag display component
 const TagDisplay: React.FC<{ tag: EnhancedTag; compact?: boolean }> = ({ tag, compact = false }) => {
@@ -378,7 +118,7 @@ export const LessonsListScreen: React.FC<LessonsListScreenProps> = ({
   const [lastScrollY, setLastScrollY] = useState(0);
   const [isPaywallOpen, setIsPaywallOpen] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
-  const lessonsPerPage = 5; // Количество уроков на странице
+  const lessonsPerPage = LESSONS_PER_PAGE; // Количество уроков на странице
 
   const { data, isLoading } = useLessons({ 
     moduleRef, 
@@ -809,22 +549,12 @@ export const LessonsListScreen: React.FC<LessonsListScreenProps> = ({
 
   const getDifficultyColor = (difficulty?: LessonDifficulty) => {
     if (!difficulty) return "text-gray-600 bg-gray-50";
-    const colors = {
-      easy: "text-green-600 bg-green-50",
-      medium: "text-yellow-600 bg-yellow-50", 
-      hard: "text-red-600 bg-red-50"
-    };
-    return colors[difficulty] || "text-gray-600 bg-gray-50";
+    return LESSON_DIFFICULTY_COLORS[difficulty] || "text-gray-600 bg-gray-50";
   };
 
   const getDifficultyText = (difficulty?: LessonDifficulty) => {
     if (!difficulty) return "Неизвестно";
-    const texts = {
-      easy: "Легко",
-      medium: "Средне",
-      hard: "Сложно"
-    };
-    return texts[difficulty] || "Неизвестно";
+    return LESSON_DIFFICULTY_LABELS[difficulty] || "Неизвестно";
   };
 
   const getProgressIcon = (lesson: LessonItem) => {

--- a/src/features/LessonsListScreen/utils.ts
+++ b/src/features/LessonsListScreen/utils.ts
@@ -1,0 +1,167 @@
+import type { LessonItem, LessonType, TaskType } from '../../types';
+import {
+  LESSON_TYPE_ICONS,
+  LESSON_TYPE_LABELS,
+  TAG_CONFIG,
+  type EnhancedTag
+} from './constants';
+
+// Utility functions
+export const getDefaultTaskTypes = (lessonType: LessonType): TaskType[] => {
+  const taskTypesMap: Record<LessonType, TaskType[]> = {
+    vocabulary: ['flashcard', 'multiple_choice', 'matching'],
+    grammar: ['gap_fill', 'multiple_choice', 'flashcard'],
+    listening: ['listening', 'multiple_choice', 'gap_fill'],
+    speaking: ['flashcard', 'gap_fill', 'multiple_choice'],
+    reading: ['multiple_choice', 'gap_fill', 'flashcard'],
+    writing: ['gap_fill', 'multiple_choice', 'flashcard'],
+    conversation: ['flashcard', 'listening', 'multiple_choice']
+  };
+
+  return taskTypesMap[lessonType] || ['flashcard', 'multiple_choice'];
+};
+
+// Map API task types to internal TaskType format
+export const mapApiTaskTypes = (apiTaskTypes: string[]): TaskType[] => {
+  const taskTypeMapping: Record<string, TaskType> = {
+    'choice': 'multiple_choice',
+    'translate': 'flashcard', // Assuming translate tasks are flashcards
+    'gap': 'gap_fill',
+    'listening': 'listening',
+    'matching': 'matching',
+    'flashcard': 'flashcard',
+    'multiple_choice': 'multiple_choice',
+    'gap_fill': 'gap_fill'
+  };
+
+  const mappedTypes = apiTaskTypes
+    .map(type => taskTypeMapping[type])
+    .filter((type): type is TaskType => type !== undefined);
+
+  // Debug logging
+  if (import.meta.env.VITE_ENABLE_DEBUG_LOGGING) {
+    console.log('Mapping API task types:', apiTaskTypes, '->', mappedTypes);
+  }
+
+  return mappedTypes;
+};
+
+// Get available lesson types from current lessons
+export const getAvailableLessonTypes = (lessons: LessonItem[]): Array<{key: LessonType | 'all', label: string, icon: string}> => {
+  const availableTypes = new Set<LessonType>();
+
+  lessons.forEach(lesson => {
+    if (lesson.type) {
+      availableTypes.add(lesson.type);
+    }
+  });
+
+  const options: Array<{key: LessonType | 'all', label: string, icon: string}> = [
+    { key: 'all', label: 'Все', icon: '📚' }
+  ];
+
+  // Add available types in a consistent order
+  const typeOrder: LessonType[] = ['vocabulary', 'grammar', 'listening', 'speaking', 'reading', 'writing', 'conversation'];
+
+  typeOrder.forEach(type => {
+    if (availableTypes.has(type)) {
+      options.push({
+        key: type,
+        label: LESSON_TYPE_LABELS[type],
+        icon: LESSON_TYPE_ICONS[type]
+      });
+    }
+  });
+
+  return options;
+};
+
+export const getLessonTypeIcon = (type?: LessonType) => {
+  if (!type) return "📚";
+  return LESSON_TYPE_ICONS[type] || "📚";
+};
+
+export const getLessonTypeLabel = (type: LessonType): string => {
+  return LESSON_TYPE_LABELS[type] || 'Урок';
+};
+
+// Enhanced tag processing functions
+export const getEnhancedTags = (lesson: LessonItem): EnhancedTag[] => {
+  const tags: EnhancedTag[] = [];
+
+  // Add lesson type tag with enhanced styling
+  if (lesson.type) {
+    const typeTag: EnhancedTag = {
+      id: `type-${lesson.type}`,
+      label: getLessonTypeLabel(lesson.type),
+      icon: getLessonTypeIcon(lesson.type),
+      category: 'skill',
+      color: 'text-telegram-accent',
+      bgColor: 'bg-telegram-accent/10',
+      priority: 10
+    };
+    tags.push(typeTag);
+  }
+
+  // Add media tags based on lesson properties
+  if (lesson.hasAudio) {
+    tags.push(TAG_CONFIG.audio);
+  }
+  if (lesson.hasVideo) {
+    tags.push(TAG_CONFIG.video);
+  }
+
+  // Process original string tags and map them to enhanced tags
+  lesson.tags?.forEach(tagString => {
+    const enhancedTag = TAG_CONFIG[tagString];
+    if (enhancedTag) {
+      tags.push(enhancedTag);
+    } else {
+      // Create fallback tag for unknown tags
+      tags.push({
+        id: `custom-${tagString}`,
+        label: tagString.charAt(0).toUpperCase() + tagString.slice(1),
+        icon: '🏷️',
+        category: 'general',
+        color: 'text-gray-600',
+        bgColor: 'bg-gray-50',
+        priority: 2
+      });
+    }
+  });
+
+  // Add special tags based on lesson properties
+  if (lesson.difficulty === 'easy' || lesson.tags?.includes('basics')) {
+    tags.push(TAG_CONFIG.beginner);
+  }
+
+  // Add "new" tag for recently added lessons (mock logic)
+  if (lesson.order <= 3) {
+    tags.push(TAG_CONFIG.new);
+  }
+
+  // Add "important" tag for high XP lessons
+  if (lesson.xpReward && lesson.xpReward >= 40) {
+    tags.push(TAG_CONFIG.important);
+  }
+
+  // Remove duplicates and sort by priority
+  const uniqueTags = tags.filter((tag, index, self) =>
+    index === self.findIndex(t => t.id === tag.id)
+  );
+
+  return uniqueTags.sort((a, b) => b.priority - a.priority);
+};
+
+export const pluralize = (count: number, forms: [string, string, string]): string => {
+  const mod10 = count % 10;
+  const mod100 = count % 100;
+
+  if (mod10 === 1 && mod100 !== 11) {
+    return forms[0];
+  }
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)) {
+    return forms[1];
+  }
+  return forms[2];
+};


### PR DESCRIPTION
### Motivation
- Move pure helper logic out of the component to improve readability and reuse by extracting utilities from `index.tsx` into a dedicated module.  
- Centralize task type, tag and lesson-type processing so the same helpers can be reused across the feature.  
- Reduce the size and responsibility of `LessonsListScreen` to make future refactors and tests easier.  

### Description
- Add `src/features/LessonsListScreen/utils.ts` and export `getDefaultTaskTypes`, `mapApiTaskTypes`, `getAvailableLessonTypes`, `getLessonTypeIcon`, `getLessonTypeLabel`, `getEnhancedTags`, and `pluralize`.  
- Update `src/features/LessonsListScreen/index.tsx` to import the extracted helpers from `./utils` and to consume constants from `./constants` such as `LESSONS_PER_PAGE`, `LESSON_DIFFICULTY_COLORS`, `LESSON_DIFFICULTY_LABELS`, and `TASK_TYPES_CONFIG`.  
- Remove duplicate inline implementations from `index.tsx` and preserve existing UI/behavior (task mapping, tag enhancement, lesson-type metadata).  
- Add optional debug logging in `mapApiTaskTypes` behind `import.meta.env.VITE_ENABLE_DEBUG_LOGGING`.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f03f370648320995c956c9be2ba0c)