### PR TITLE
Refactor LessonsListScreen utilities into utils.ts

### DIFF
--- a/src/features/LessonsListScreen/index.tsx
+++ b/src/features/LessonsListScreen/index.tsx
@@ -13,12 +13,16 @@ import {
   LESSONS_PER_PAGE,
   LESSON_DIFFICULTY_COLORS,
   LESSON_DIFFICULTY_LABELS,
-  LESSON_TYPE_ICONS,
-  LESSON_TYPE_LABELS,
-  TAG_CONFIG,
   TASK_TYPES_CONFIG,
   type EnhancedTag
 } from './constants';
+import {
+  getDefaultTaskTypes,
+  mapApiTaskTypes,
+  getAvailableLessonTypes,
+  getEnhancedTags,
+  pluralize
+} from './utils';
 import './styles.lessonsList.css';
 
 interface LessonsListScreenProps {
@@ -26,153 +30,6 @@ interface LessonsListScreenProps {
   moduleTitle?: string;
   level?: string;
 }
-
-// Utility functions
-const getDefaultTaskTypes = (lessonType: LessonType): TaskType[] => {
-  const taskTypesMap: Record<LessonType, TaskType[]> = {
-    vocabulary: ['flashcard', 'multiple_choice', 'matching'],
-    grammar: ['gap_fill', 'multiple_choice', 'flashcard'],
-    listening: ['listening', 'multiple_choice', 'gap_fill'],
-    speaking: ['flashcard', 'gap_fill', 'multiple_choice'],
-    reading: ['multiple_choice', 'gap_fill', 'flashcard'],
-    writing: ['gap_fill', 'multiple_choice', 'flashcard'],
-    conversation: ['flashcard', 'listening', 'multiple_choice']
-  };
-  
-  return taskTypesMap[lessonType] || ['flashcard', 'multiple_choice'];
-};
-
-// Map API task types to internal TaskType format
-const mapApiTaskTypes = (apiTaskTypes: string[]): TaskType[] => {
-  const taskTypeMapping: Record<string, TaskType> = {
-    'choice': 'multiple_choice',
-    'translate': 'flashcard', // Assuming translate tasks are flashcards
-    'gap': 'gap_fill',
-    'listening': 'listening',
-    'matching': 'matching',
-    'flashcard': 'flashcard',
-    'multiple_choice': 'multiple_choice',
-    'gap_fill': 'gap_fill'
-  };
-  
-  const mappedTypes = apiTaskTypes
-    .map(type => taskTypeMapping[type])
-    .filter((type): type is TaskType => type !== undefined);
-  
-  // Debug logging
-  if (import.meta.env.VITE_ENABLE_DEBUG_LOGGING) {
-    console.log('Mapping API task types:', apiTaskTypes, '->', mappedTypes);
-  }
-  
-  return mappedTypes;
-};
-
-// Get available lesson types from current lessons
-const getAvailableLessonTypes = (lessons: LessonItem[]): Array<{key: LessonType | 'all', label: string, icon: string}> => {
-  const availableTypes = new Set<LessonType>();
-  
-  lessons.forEach(lesson => {
-    if (lesson.type) {
-      availableTypes.add(lesson.type);
-    }
-  });
-  
-  const options: Array<{key: LessonType | 'all', label: string, icon: string}> = [
-    { key: 'all', label: 'Все', icon: '📚' }
-  ];
-  
-  // Add available types in a consistent order
-  const typeOrder: LessonType[] = ['vocabulary', 'grammar', 'listening', 'speaking', 'reading', 'writing', 'conversation'];
-  
-  typeOrder.forEach(type => {
-    if (availableTypes.has(type)) {
-      options.push({
-        key: type,
-        label: LESSON_TYPE_LABELS[type],
-        icon: LESSON_TYPE_ICONS[type]
-      });
-    }
-  });
-  
-  return options;
-};
-
-const getLessonTypeIcon = (type?: LessonType) => {
-  if (!type) return "📚";
-  return LESSON_TYPE_ICONS[type] || "📚";
-};
-
-// Enhanced tag processing functions
-const getEnhancedTags = (lesson: LessonItem): EnhancedTag[] => {
-  const tags: EnhancedTag[] = [];
-  
-  // Add lesson type tag with enhanced styling
-  if (lesson.type) {
-    const typeTag: EnhancedTag = {
-      id: `type-${lesson.type}`,
-      label: getLessonTypeLabel(lesson.type),
-      icon: getLessonTypeIcon(lesson.type),
-      category: 'skill',
-      color: 'text-telegram-accent',
-      bgColor: 'bg-telegram-accent/10',
-      priority: 10
-    };
-    tags.push(typeTag);
-  }
-  
-  // Add media tags based on lesson properties
-  if (lesson.hasAudio) {
-    tags.push(TAG_CONFIG.audio);
-  }
-  if (lesson.hasVideo) {
-    tags.push(TAG_CONFIG.video);
-  }
-  
-  // Process original string tags and map them to enhanced tags
-  lesson.tags?.forEach(tagString => {
-    const enhancedTag = TAG_CONFIG[tagString];
-    if (enhancedTag) {
-      tags.push(enhancedTag);
-    } else {
-      // Create fallback tag for unknown tags
-      tags.push({
-        id: `custom-${tagString}`,
-        label: tagString.charAt(0).toUpperCase() + tagString.slice(1),
-        icon: '🏷️',
-        category: 'general',
-        color: 'text-gray-600',
-        bgColor: 'bg-gray-50',
-        priority: 2
-      });
-    }
-  });
-  
-  // Add special tags based on lesson properties
-  if (lesson.difficulty === 'easy' || lesson.tags?.includes('basics')) {
-    tags.push(TAG_CONFIG.beginner);
-  }
-  
-  // Add "new" tag for recently added lessons (mock logic)
-  if (lesson.order <= 3) {
-    tags.push(TAG_CONFIG.new);
-  }
-  
-  // Add "important" tag for high XP lessons
-  if (lesson.xpReward && lesson.xpReward >= 40) {
-    tags.push(TAG_CONFIG.important);
-  }
-  
-  // Remove duplicates and sort by priority
-  const uniqueTags = tags.filter((tag, index, self) => 
-    index === self.findIndex(t => t.id === tag.id)
-  );
-  
-  return uniqueTags.sort((a, b) => b.priority - a.priority);
-};
-
-const getLessonTypeLabel = (type: LessonType): string => {
-  return LESSON_TYPE_LABELS[type] || 'Урок';
-};
 
 // Enhanced tag display component
 const TagDisplay: React.FC<{ tag: EnhancedTag; compact?: boolean }> = ({ tag, compact = false }) => {
@@ -1158,10 +1015,8 @@ export const LessonsListScreen: React.FC<LessonsListScreenProps> = ({
                 )}
                 {animatedProgress > 0 && animatedProgress < 100 && (
                   <p className="text-xs text-telegram-hint">
-                    Осталось {moduleStats.total - moduleStats.completed} {
-                      moduleStats.total - moduleStats.completed === 1 ? 'урок' : 
-                      moduleStats.total - moduleStats.completed < 5 ? 'урока' : 'уроков'
-                    }
+                    Осталось {moduleStats.total - moduleStats.completed}{' '}
+                    {pluralize(moduleStats.total - moduleStats.completed, 'урок', 'урока', 'уроков')}
                   </p>
                 )}
                 {animatedProgress >= 100 && (

--- a/src/features/LessonsListScreen/utils.ts
+++ b/src/features/LessonsListScreen/utils.ts
@@ -1,0 +1,141 @@
+import type { LessonItem, LessonType, TaskType } from '../../types';
+import { LESSON_TYPE_ICONS, LESSON_TYPE_LABELS, TAG_CONFIG, type EnhancedTag } from './constants';
+
+export const getDefaultTaskTypes = (lessonType: LessonType): TaskType[] => {
+  const taskTypesMap: Record<LessonType, TaskType[]> = {
+    vocabulary: ['flashcard', 'multiple_choice', 'matching'],
+    grammar: ['gap_fill', 'multiple_choice', 'flashcard'],
+    listening: ['listening', 'multiple_choice', 'gap_fill'],
+    speaking: ['flashcard', 'gap_fill', 'multiple_choice'],
+    reading: ['multiple_choice', 'gap_fill', 'flashcard'],
+    writing: ['gap_fill', 'multiple_choice', 'flashcard'],
+    conversation: ['flashcard', 'listening', 'multiple_choice']
+  };
+
+  return taskTypesMap[lessonType] || ['flashcard', 'multiple_choice'];
+};
+
+export const mapApiTaskTypes = (apiTaskTypes: string[]): TaskType[] => {
+  const taskTypeMapping: Record<string, TaskType> = {
+    choice: 'multiple_choice',
+    translate: 'flashcard',
+    gap: 'gap_fill',
+    listening: 'listening',
+    matching: 'matching',
+    flashcard: 'flashcard',
+    multiple_choice: 'multiple_choice',
+    gap_fill: 'gap_fill'
+  };
+
+  const mappedTypes = apiTaskTypes
+    .map(type => taskTypeMapping[type])
+    .filter((type): type is TaskType => type !== undefined);
+
+  if (import.meta.env.VITE_ENABLE_DEBUG_LOGGING) {
+    console.log('Mapping API task types:', apiTaskTypes, '->', mappedTypes);
+  }
+
+  return mappedTypes;
+};
+
+export const getAvailableLessonTypes = (
+  lessons: LessonItem[]
+): Array<{ key: LessonType | 'all'; label: string; icon: string }> => {
+  const availableTypes = new Set<LessonType>();
+
+  lessons.forEach(lesson => {
+    if (lesson.type) {
+      availableTypes.add(lesson.type);
+    }
+  });
+
+  const options: Array<{ key: LessonType | 'all'; label: string; icon: string }> = [
+    { key: 'all', label: 'Все', icon: '📚' }
+  ];
+
+  const typeOrder: LessonType[] = ['vocabulary', 'grammar', 'listening', 'speaking', 'reading', 'writing', 'conversation'];
+
+  typeOrder.forEach(type => {
+    if (availableTypes.has(type)) {
+      options.push({
+        key: type,
+        label: LESSON_TYPE_LABELS[type],
+        icon: LESSON_TYPE_ICONS[type]
+      });
+    }
+  });
+
+  return options;
+};
+
+export const getLessonTypeIcon = (type?: LessonType) => {
+  if (!type) return '📚';
+  return LESSON_TYPE_ICONS[type] || '📚';
+};
+
+export const getLessonTypeLabel = (type: LessonType): string => {
+  return LESSON_TYPE_LABELS[type] || 'Урок';
+};
+
+export const getEnhancedTags = (lesson: LessonItem): EnhancedTag[] => {
+  const tags: EnhancedTag[] = [];
+
+  if (lesson.type) {
+    const typeTag: EnhancedTag = {
+      id: `type-${lesson.type}`,
+      label: getLessonTypeLabel(lesson.type),
+      icon: getLessonTypeIcon(lesson.type),
+      category: 'skill',
+      color: 'text-telegram-accent',
+      bgColor: 'bg-telegram-accent/10',
+      priority: 10
+    };
+    tags.push(typeTag);
+  }
+
+  if (lesson.hasAudio) {
+    tags.push(TAG_CONFIG.audio);
+  }
+  if (lesson.hasVideo) {
+    tags.push(TAG_CONFIG.video);
+  }
+
+  lesson.tags?.forEach(tagString => {
+    const enhancedTag = TAG_CONFIG[tagString];
+    if (enhancedTag) {
+      tags.push(enhancedTag);
+    } else {
+      tags.push({
+        id: `custom-${tagString}`,
+        label: tagString.charAt(0).toUpperCase() + tagString.slice(1),
+        icon: '🏷️',
+        category: 'general',
+        color: 'text-gray-600',
+        bgColor: 'bg-gray-50',
+        priority: 2
+      });
+    }
+  });
+
+  if (lesson.difficulty === 'easy' || lesson.tags?.includes('basics')) {
+    tags.push(TAG_CONFIG.beginner);
+  }
+
+  if (lesson.order <= 3) {
+    tags.push(TAG_CONFIG.new);
+  }
+
+  if (lesson.xpReward && lesson.xpReward >= 40) {
+    tags.push(TAG_CONFIG.important);
+  }
+
+  const uniqueTags = tags.filter((tag, index, self) => index === self.findIndex(t => t.id === tag.id));
+
+  return uniqueTags.sort((a, b) => b.priority - a.priority);
+};
+
+export const pluralize = (count: number, one: string, few: string, many: string): string => {
+  if (count === 1) return one;
+  if (count < 5) return few;
+  return many;
+};


### PR DESCRIPTION
### Motivation
- Reduce file size and improve organization by extracting pure helper functions used by `LessonsListScreen` into a single utilities module.
- Make helper logic (task type mapping, lesson type metadata, tag enhancement and pluralization) reusable and easier to test.
- Keep existing UI behavior unchanged (1-в-1) while centralizing logic.

### Description
- Added `src/features/LessonsListScreen/utils.ts` and moved `getDefaultTaskTypes`, `mapApiTaskTypes`, `getAvailableLessonTypes`, `getLessonTypeLabel`/`getLessonTypeIcon`, `getEnhancedTags`, and `pluralize` into it.
- Updated `src/features/LessonsListScreen/index.tsx` imports to consume the new utilities and removed the in-file implementations.
- Replaced inline pluralization logic with the new `pluralize` helper call for lesson-count text.
- Preserved existing constants usage and component behavior, only relocating pure functions to `utils.ts`.

### Testing
- No automated tests were executed as part of this change.
- Type and lint checks were not run in this rollout.
- Manual verification focused on ensuring behavior remained identical to the prior implementation.
- No test failures reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f06be5a448320a4750ce923482868)