### PR TITLE
Extract hooks from LessonsListScreen (prepared, filtered, sticky, animated stats, vocabulary audio)

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,8 @@
 export { useAppNavigation } from './useAppNavigation';
 export { useYandexMetrika, useTrackAction } from './useYandexMetrika';
 export { usePricing } from './usePricing';
+export { usePreparedLessons } from './usePreparedLessons';
+export { useFilteredLessons } from './useFilteredLessons';
+export { useStickyBreadcrumbs } from './useStickyBreadcrumbs';
+export { useAnimatedModuleStats } from './useAnimatedModuleStats';
+export { useVocabularyAudioPreload } from './useVocabularyAudioPreload';

--- a/src/hooks/useAnimatedModuleStats.ts
+++ b/src/hooks/useAnimatedModuleStats.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import { hapticFeedback } from '../utils/telegram';
+
+interface ModuleStats {
+  completed: number;
+  total: number;
+  totalXP: number;
+}
+
+export const useAnimatedModuleStats = (moduleStats: ModuleStats) => {
+  const [animatedProgress, setAnimatedProgress] = useState(0);
+  const [animatedCompleted, setAnimatedCompleted] = useState(0);
+  const [animatedXP, setAnimatedXP] = useState(0);
+
+  useEffect(() => {
+    const targetProgress = moduleStats.total > 0
+      ? (moduleStats.completed / moduleStats.total) * 100
+      : 0;
+    const targetCompleted = moduleStats.completed;
+    const targetXP = moduleStats.totalXP;
+    const animationDuration = 1500;
+    const steps = 60;
+
+    const progressIncrement = targetProgress / steps;
+    const completedIncrement = targetCompleted / steps;
+    const xpIncrement = targetXP / steps;
+
+    let currentStep = 0;
+
+    const timer = setInterval(() => {
+      currentStep++;
+      const progressValue = Math.min(progressIncrement * currentStep, targetProgress);
+      const completedValue = Math.min(Math.round(completedIncrement * currentStep), targetCompleted);
+      const xpValue = Math.min(Math.round(xpIncrement * currentStep), targetXP);
+
+      setAnimatedProgress(progressValue);
+      setAnimatedCompleted(completedValue);
+      setAnimatedXP(xpValue);
+
+      if (currentStep >= steps) {
+        clearInterval(timer);
+        setAnimatedProgress(targetProgress);
+        setAnimatedCompleted(targetCompleted);
+        setAnimatedXP(targetXP);
+        hapticFeedback.selection();
+      }
+    }, animationDuration / steps);
+
+    return () => clearInterval(timer);
+  }, [moduleStats.completed, moduleStats.total, moduleStats.totalXP]);
+
+  return {
+    animatedProgress,
+    animatedCompleted,
+    animatedXP
+  };
+};

--- a/src/hooks/useFilteredLessons.ts
+++ b/src/hooks/useFilteredLessons.ts
@@ -1,0 +1,60 @@
+import { useMemo } from 'react';
+import type { LessonItem, LessonType } from '../types';
+
+interface UseFilteredLessonsParams {
+  lessons: LessonItem[];
+  selectedFilter: LessonType | 'all';
+  sortBy: 'order' | 'difficulty' | 'duration';
+  sortDirection: 'asc' | 'desc';
+  currentPage: number;
+  lessonsPerPage: number;
+}
+
+export const useFilteredLessons = ({
+  lessons,
+  selectedFilter,
+  sortBy,
+  sortDirection,
+  currentPage,
+  lessonsPerPage
+}: UseFilteredLessonsParams) => {
+  return useMemo(() => {
+    let filtered = selectedFilter === 'all'
+      ? lessons
+      : lessons.filter(lesson => lesson.type === selectedFilter);
+
+    filtered = [...filtered].sort((a, b) => {
+      let result = 0;
+
+      switch (sortBy) {
+        case 'difficulty': {
+          const difficultyOrder: Record<string, number> = { easy: 1, medium: 2, hard: 3, undefined: 0 };
+          const aDiff = a.difficulty || 'undefined';
+          const bDiff = b.difficulty || 'undefined';
+          result = (difficultyOrder[aDiff] || 0) - (difficultyOrder[bDiff] || 0);
+          break;
+        }
+        case 'duration':
+          result = a.estimatedMinutes - b.estimatedMinutes;
+          break;
+        case 'order':
+        default:
+          result = a.order - b.order;
+          break;
+      }
+
+      return sortDirection === 'desc' ? -result : result;
+    });
+
+    const totalPages = Math.ceil(filtered.length / lessonsPerPage);
+    const startIndex = (currentPage - 1) * lessonsPerPage;
+    const endIndex = startIndex + lessonsPerPage;
+    const paginatedLessons = filtered.slice(startIndex, endIndex);
+
+    return {
+      filteredLessons: paginatedLessons,
+      totalPages,
+      allFilteredLessons: filtered
+    };
+  }, [lessons, selectedFilter, sortBy, sortDirection, currentPage, lessonsPerPage]);
+};

--- a/src/hooks/usePreparedLessons.ts
+++ b/src/hooks/usePreparedLessons.ts
@@ -1,0 +1,205 @@
+import { useMemo } from 'react';
+import type { LessonDifficulty, LessonItem, LessonType, TaskType } from '../types';
+import { getDefaultTaskTypes, mapApiTaskTypes } from '../features/LessonsListScreen/utils';
+
+interface UsePreparedLessonsParams {
+  lessons?: LessonItem[];
+  moduleRef?: string;
+}
+
+const applyLessonDefaults = (lesson: LessonItem): LessonItem => ({
+  ...lesson,
+  type: lesson.type || ('vocabulary' as LessonType),
+  difficulty: lesson.difficulty || ('medium' as LessonDifficulty),
+  tags: lesson.tags || [],
+  xpReward: lesson.xpReward || 20,
+  hasAudio: lesson.hasAudio || false,
+  hasVideo: lesson.hasVideo || false,
+  taskTypes: lesson.taskTypes
+    ? mapApiTaskTypes(lesson.taskTypes)
+    : getDefaultTaskTypes(lesson.type || 'vocabulary')
+});
+
+const buildMockLessons = (moduleRef?: string): LessonItem[] => [
+  {
+    lessonRef: 'travel.a0.greetings',
+    moduleRef: moduleRef || 'travel.a0',
+    title: 'Приветствие и знакомство',
+    description: 'Изучите основные фразы для знакомства в аэропорту',
+    estimatedMinutes: 8,
+    order: 1,
+    type: 'conversation' as LessonType,
+    difficulty: 'easy' as LessonDifficulty,
+    tags: ['greetings', 'basics', 'airport', 'beginner'],
+    xpReward: 25,
+    hasAudio: true,
+    hasVideo: false,
+    previewText: 'Hello! My name is... Nice to meet you!',
+    taskTypes: ['flashcard', 'multiple_choice', 'listening'] as TaskType[],
+    progress: {
+      status: 'completed' as const,
+      score: 95,
+      attempts: 2,
+      completedAt: '2024-01-15T10:30:00Z',
+      timeSpent: 480
+    }
+  },
+  {
+    lessonRef: 'travel.a0.security',
+    moduleRef: moduleRef || 'travel.a0',
+    title: 'Досмотр безопасности',
+    description: 'Пройдите контроль безопасности без проблем',
+    estimatedMinutes: 12,
+    order: 2,
+    type: 'listening' as LessonType,
+    difficulty: 'medium' as LessonDifficulty,
+    tags: ['security', 'airport', 'instructions', 'important'],
+    xpReward: 35,
+    hasAudio: true,
+    hasVideo: true,
+    previewText: 'Please put your belongings in the tray...',
+    taskTypes: ['listening', 'gap_fill', 'multiple_choice'] as TaskType[],
+    progress: {
+      status: 'in_progress' as const,
+      score: 67,
+      attempts: 1,
+      timeSpent: 420
+    }
+  },
+  {
+    lessonRef: 'travel.a0.boarding',
+    moduleRef: moduleRef || 'travel.a0',
+    title: 'Посадка на самолет',
+    description: 'Найдите свое место и подготовьтесь к полету',
+    estimatedMinutes: 10,
+    order: 3,
+    type: 'vocabulary' as LessonType,
+    difficulty: 'easy' as LessonDifficulty,
+    tags: ['transport', 'airport', 'vocabulary'],
+    xpReward: 30,
+    hasAudio: true,
+    hasVideo: false,
+    previewText: 'Boarding pass, seat number, overhead compartment...',
+    taskTypes: ['flashcard', 'matching', 'gap_fill', 'multiple_choice', 'listening'] as TaskType[],
+    progress: {
+      status: 'not_started' as const,
+      score: 0,
+      attempts: 0
+    }
+  },
+  {
+    lessonRef: 'travel.a0.flight',
+    moduleRef: moduleRef || 'travel.a0',
+    title: 'Во время полета',
+    description: 'Общение с экипажем и пассажирами',
+    estimatedMinutes: 15,
+    order: 4,
+    type: 'conversation' as LessonType,
+    difficulty: 'medium' as LessonDifficulty,
+    tags: ['transport', 'ordering', 'popular'],
+    xpReward: 40,
+    hasAudio: true,
+    hasVideo: true,
+    previewText: 'Excuse me, could I have some water please?',
+    taskTypes: ['flashcard', 'gap_fill'] as TaskType[],
+    isLocked: true,
+    unlockCondition: 'Завершите урок "Посадка на самолет"'
+  },
+  {
+    lessonRef: 'travel.a0.arrival',
+    moduleRef: moduleRef || 'travel.a0',
+    title: 'Прибытие и паспортный контроль',
+    description: 'Пройдите паспортный контроль и получите багаж',
+    estimatedMinutes: 18,
+    order: 5,
+    type: 'grammar' as LessonType,
+    difficulty: 'hard' as LessonDifficulty,
+    tags: ['airport', 'passport', 'customs', 'important'],
+    xpReward: 50,
+    hasAudio: true,
+    hasVideo: true,
+    previewText: 'Purpose of visit, duration of stay, customs declaration...',
+    taskTypes: ['matching', 'multiple_choice', 'listening'] as TaskType[],
+    isLocked: true,
+    unlockCondition: 'Завершите урок "Во время полета"'
+  },
+  {
+    lessonRef: 'travel.a0.hotel',
+    moduleRef: moduleRef || 'travel.a0',
+    title: 'Заселение в отель',
+    description: 'Зарегистрируйтесь в отеле и узнайте о услугах',
+    estimatedMinutes: 14,
+    order: 6,
+    type: 'speaking' as LessonType,
+    difficulty: 'medium' as LessonDifficulty,
+    tags: ['hotel', 'check-in', 'popular'],
+    xpReward: 35,
+    hasAudio: true,
+    hasVideo: false,
+    previewText: 'I have a reservation under the name...',
+    isLocked: true,
+    unlockCondition: 'Завершите урок "Прибытие и паспортный контроль"'
+  },
+  {
+    lessonRef: 'travel.a0.restaurant',
+    moduleRef: moduleRef || 'travel.a0',
+    title: 'В ресторане',
+    description: 'Закажите еду и пообщайтесь с официантом',
+    estimatedMinutes: 16,
+    order: 7,
+    type: 'conversation' as LessonType,
+    difficulty: 'medium' as LessonDifficulty,
+    tags: ['restaurant', 'ordering', 'popular'],
+    xpReward: 40,
+    hasAudio: true,
+    hasVideo: true,
+    previewText: "Could I see the menu, please? I'd like to order...",
+    isLocked: true,
+    unlockCondition: 'Завершите урок "Заселение в отель"'
+  },
+  {
+    lessonRef: 'travel.a0.directions',
+    moduleRef: moduleRef || 'travel.a0',
+    title: 'Спросить дорогу',
+    description: 'Научитесь спрашивать и понимать направления',
+    estimatedMinutes: 12,
+    order: 8,
+    type: 'listening' as LessonType,
+    difficulty: 'easy' as LessonDifficulty,
+    tags: ['city', 'directions', 'beginner'],
+    xpReward: 30,
+    hasAudio: true,
+    hasVideo: false,
+    previewText: 'Excuse me, how do I get to...? Go straight, turn left...',
+    isLocked: true,
+    unlockCondition: 'Завершите урок "В ресторане"'
+  }
+];
+
+export const usePreparedLessons = ({ lessons, moduleRef }: UsePreparedLessonsParams) => {
+  return useMemo(() => {
+    const apiLessons = (lessons || []).map(applyLessonDefaults);
+    const shouldUseMock = !lessons || lessons.length === 0;
+    const mockLessons = shouldUseMock ? buildMockLessons(moduleRef) : [];
+    const allLessons = [...apiLessons, ...mockLessons];
+
+    const sortedLessons = [...allLessons].sort((a, b) => a.order - b.order);
+
+    return sortedLessons.map((lesson, index, orderedLessons) => {
+      if (index === 0) {
+        return { ...lesson, isLocked: false };
+      }
+
+      const previousLesson = orderedLessons[index - 1];
+      const isPreviousCompleted = previousLesson?.progress?.status === 'completed';
+
+      return {
+        ...lesson,
+        isLocked: !isPreviousCompleted,
+        unlockCondition: !isPreviousCompleted
+          ? `Завершите урок "${previousLesson?.title}"`
+          : lesson.unlockCondition
+      };
+    });
+  }, [lessons, moduleRef]);
+};

--- a/src/hooks/useStickyBreadcrumbs.ts
+++ b/src/hooks/useStickyBreadcrumbs.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+
+export const useStickyBreadcrumbs = (screenRef: RefObject<HTMLElement>) => {
+  const [showStickyBreadcrumbs, setShowStickyBreadcrumbs] = useState(false);
+  const lastScrollY = useRef(0);
+
+  useEffect(() => {
+    let ticking = false;
+
+    const handleScroll = (event: Event) => {
+      if (ticking) {
+        return;
+      }
+
+      ticking = true;
+      requestAnimationFrame(() => {
+        const target = event.target as HTMLElement;
+        const currentScrollY = target.scrollTop;
+        const direction = currentScrollY > lastScrollY.current ? 'down' : 'up';
+        const threshold = 120;
+
+        if (currentScrollY < threshold) {
+          setShowStickyBreadcrumbs(false);
+        } else if (direction === 'down') {
+          setShowStickyBreadcrumbs(true);
+        } else {
+          setShowStickyBreadcrumbs(false);
+        }
+
+        lastScrollY.current = currentScrollY;
+        ticking = false;
+      });
+    };
+
+    const screenElement = screenRef.current;
+    if (!screenElement) {
+      return undefined;
+    }
+
+    screenElement.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      screenElement.removeEventListener('scroll', handleScroll);
+    };
+  }, [screenRef]);
+
+  return { showStickyBreadcrumbs };
+};

--- a/src/hooks/useVocabularyAudioPreload.ts
+++ b/src/hooks/useVocabularyAudioPreload.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import type { ModuleVocabularyResponse } from '../types';
+import { useAudioPreload } from '../utils/audio';
+
+interface UseVocabularyAudioPreloadParams {
+  activeTab: 'lessons' | 'vocabulary';
+  vocabularyData?: ModuleVocabularyResponse;
+}
+
+export const useVocabularyAudioPreload = ({
+  activeTab,
+  vocabularyData
+}: UseVocabularyAudioPreloadParams) => {
+  const { isPreloading, preloadAudioFiles, getPreloadedAudio } = useAudioPreload();
+  const [preloadedAudioMap, setPreloadedAudioMap] = useState<Map<string, HTMLAudioElement>>(new Map());
+  const [loadedAudioUrls, setLoadedAudioUrls] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (activeTab !== 'vocabulary' || !vocabularyData?.vocabulary || isPreloading) {
+      return;
+    }
+
+    const audioUrls = vocabularyData.vocabulary
+      .map(item => item.pronunciation)
+      .filter(Boolean) as string[];
+
+    const newAudioUrls = audioUrls.filter(url => !loadedAudioUrls.has(url));
+
+    if (newAudioUrls.length === 0) {
+      return;
+    }
+
+    console.log('Silently preloading audio for vocabulary tab:', newAudioUrls.length, 'files');
+    setLoadedAudioUrls(prev => new Set([...prev, ...newAudioUrls]));
+
+    preloadAudioFiles(newAudioUrls).then(() => {
+      setPreloadedAudioMap(prevMap => {
+        const newMap = new Map(prevMap);
+        newAudioUrls.forEach(url => {
+          const audio = getPreloadedAudio(url);
+          if (audio) {
+            newMap.set(url, audio);
+          }
+        });
+        return newMap;
+      });
+    });
+  }, [activeTab, vocabularyData, preloadAudioFiles, getPreloadedAudio, isPreloading, loadedAudioUrls]);
+
+  return { preloadedAudioMap, isPreloading };
+};


### PR DESCRIPTION
### Motivation
- Split complex UI logic out of `LessonsListScreen` to improve readability and reusability.
- Move data preparation, sorting/pagination, scroll behaviour, animated stats and audio preloading into focused hooks.
- Provide a mock fallback and sequential lock/unlock logic in one place for consistent lesson state.
- Make `LessonsListScreen` an orchestrator that consumes hook outputs instead of implementing low-level logic.

### Description
- Added new hooks: `src/hooks/usePreparedLessons.ts`, `src/hooks/useFilteredLessons.ts`, `src/hooks/useStickyBreadcrumbs.ts`, `src/hooks/useAnimatedModuleStats.ts`, and `src/hooks/useVocabularyAudioPreload.ts` with the corresponding logic extracted from the screen.
- Updated `src/hooks/index.ts` to export the new hooks and refactored `src/features/LessonsListScreen/index.tsx` to use `usePreparedLessons`, `useFilteredLessons`, `useStickyBreadcrumbs`, `useAnimatedModuleStats`, and `useVocabularyAudioPreload` for orchestration.
- `usePreparedLessons` applies defaults, provides a rich mock fallback when API data is empty, sorts lessons and applies sequential lock/unlock based on previous lesson progress.
- `useFilteredLessons` handles filtering, sorting (`order`, `difficulty`, `duration`) and pagination, while `useAnimatedModuleStats` and `useVocabularyAudioPreload` encapsulate animation/haptic and audio preloading respectively.

### Testing
- No automated tests were executed as part of this change.
- Manual verification steps (not automated) are recommended: navigate to the lessons screen, switch tabs, exercise filters/sorting/pagination, and observe animations and audio preload behaviour.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f0856f8148320a081309692da9d98)