### PR TITLE
Support localized module titles/descriptions and use localization helper in ModulesScreen

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -207,11 +207,13 @@ export interface ModuleProgress {
   inProgress: number;
 }
 
+export type LocalizedText = string | Record<string, string>;
+
 export interface ModuleItem {
   moduleRef: string;
   level: 'A0' | 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2'; // Уровни сложности
-  title: string;
-  description: string;
+  title: LocalizedText;
+  description: LocalizedText;
   tags: string[];
   order: number;
   progress?: ModuleProgress; // present only if userId provided


### PR DESCRIPTION
### Motivation
- Backend may return localized objects for module `title`/`description` (e.g., `{ ru: string; en: string }`) so the frontend needs to accept those shapes.
- Existing modules can still be plain `string`, so we need a union type and safe fallback behavior.
- When rendering modules and navigating to lessons, the UI must display the correct language string instead of raw objects.

### Description
- Added a `LocalizedText` type and changed `ModuleItem.title` and `ModuleItem.description` to `LocalizedText` in `src/types/index.ts`.
- Implemented `getLocalizedText(value, lang)` and language normalization logic in `src/features/ModulesScreen.tsx` to pick the correct localized string with fallbacks.
- Replaced direct uses of `m.title` / `m.description` and the `moduleTitle` navigation param with values produced by `getLocalizedText` in `ModulesScreen`.
- Files modified: `src/types/index.ts` and `src/features/ModulesScreen.tsx`.

### Testing
- No automated tests were run on this change.
- Type-checking or CI build was not executed as part of this PR preparation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69503ec524f483209b880be0470bfc4d)